### PR TITLE
pygeoweaver start argument issue

### DIFF
--- a/book/chapters/intro_to_swe_workflow_geoweaver.ipynb
+++ b/book/chapters/intro_to_swe_workflow_geoweaver.ipynb
@@ -158,6 +158,7 @@
    ],
    "source": [
     "import pygeoweaver\n",
+    "# use pygeoweaver.start() if below command doesn't work\n",
     "pygeoweaver.start(force=True)"
    ]
   },


### PR DESCRIPTION
Just mentioned to use `pygeoweaver.start()` if argument `force=True` gives error. This PR resolves [issue 39](https://github.com/geo-smart/swe-workflow-book/issues/39)